### PR TITLE
Update command namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@ All notable changes to BrightComponents/Responders will be documented in this fi
 - Change command namespace to 'bright' from 'make'.
 - Start adding tests.
 - Replace command 'name' property with 'signature' property.
+
+## 0.1.3 - 2018-07-26
+
+- With the new bright-components/adr package, we're renaming the command namespace to "adr" from "bright".

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To begin using BrightComponents/Responders, simply follow the instructions above
 To generate an IndexResponder for Posts, as in the example above, enter the following command into your terminal:
 
 ```bash
-php artisan make:responder Post\\IndexResponder
+php artisan adr:responder Post\\IndexResponder
 ```
 
 Then add the responder as a dependency to your controller and call the ```respond``` method. This method expects an instance of ```Illuminate\Http\Request``` and an optional $data object:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bright-components/responders",
     "description": "Responder Implementation for Laravel Projects",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "keywords": [
         "bright-components",
         "responders"

--- a/src/Commands/ResponderMakeCommand.php
+++ b/src/Commands/ResponderMakeCommand.php
@@ -12,7 +12,7 @@ class ResponderMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'bright:responder {name}';
+    protected $signature = 'adr:responder {name}';
 
     /**
      * The console command description.

--- a/tests/Integration/CommandTest.php
+++ b/tests/Integration/CommandTest.php
@@ -9,7 +9,7 @@ class CommandTest extends IntegrationTestCase
     /** @test */
     public function bright_responder_command_makes_responder_with_correct_respond_method()
     {
-        Artisan::call('bright:responder', ['name' => 'MyResponder']);
+        Artisan::call('adr:responder', ['name' => 'MyResponder']);
 
         include_once base_path().'/app/Http/Responders/MyResponder.php';
 


### PR DESCRIPTION
- With the new bright-components/adr package, we're changing the command namespace from 'bright' to 'adr'.